### PR TITLE
Fix bug that player's energy point set 2 points

### DIFF
--- a/Assets/_Scripts/Game/BackendDirector.cs
+++ b/Assets/_Scripts/Game/BackendDirector.cs
@@ -231,7 +231,7 @@ namespace ChessCrush.Game
             };
 
             Backend.Match.OnMatchChat += args => { };
-            Backend.Match.OnMatchResult += args => chessGameDirector.chessGameUI.gameOverWidget.gameObject.SetActive(true);
+
             Backend.Match.OnLeaveInGameServer += args => 
             {
                 gameServerJoined = false;
@@ -752,6 +752,8 @@ namespace ChessCrush.Game
                 else
                     Backend.Match.MatchEnd(new MatchGameResult { m_winners = new List<SessionId> { GetOppositeSessionId() }, m_losers = new List<SessionId> { GetMySessionId() } });
             }
+
+            chessGameDirector.chessGameUI.gameOverWidget.gameObject.SetActive(playerWin);
         }
     }
 }

--- a/Assets/_Scripts/Game/BackendDirector.cs
+++ b/Assets/_Scripts/Game/BackendDirector.cs
@@ -753,7 +753,7 @@ namespace ChessCrush.Game
                     Backend.Match.MatchEnd(new MatchGameResult { m_winners = new List<SessionId> { GetOppositeSessionId() }, m_losers = new List<SessionId> { GetMySessionId() } });
             }
 
-            chessGameDirector.chessGameUI.gameOverWidget.gameObject.SetActive(playerWin);
+            chessGameDirector.chessGameUI.gameOverWidget.gameObject.SetActive(true);
         }
     }
 }

--- a/Assets/_Scripts/Game/ChessGameDirector.cs
+++ b/Assets/_Scripts/Game/ChessGameDirector.cs
@@ -81,9 +81,7 @@ namespace ChessCrush.Game
                 actionAnimation = null;
                 StopAllCoroutines();
 
-                isPlayerWin = false;
-                chessGameUI.gameOverWidget.gameObject.SetActive(true);
-                backendDirector.MatchEnd(isPlayerWin);
+                backendDirector.MatchEnd(isPlayerWin = false);
             });
 
             enemyPlayer.Hp.Where(value => value <= 0).Subscribe(_ =>
@@ -91,10 +89,7 @@ namespace ChessCrush.Game
                 actionAnimation?.Kill(true);
                 actionAnimation = null;
                 StopAllCoroutines();
-
-                isPlayerWin = true;
-                chessGameUI.gameOverWidget.gameObject.SetActive(true);
-                backendDirector.MatchEnd(isPlayerWin);
+                backendDirector.MatchEnd(isPlayerWin = true);
             });
 
             gameReadyEvents();

--- a/Assets/_Scripts/Game/ChessGameDirector.cs
+++ b/Assets/_Scripts/Game/ChessGameDirector.cs
@@ -170,7 +170,9 @@ namespace ChessCrush.Game
             gameObject.SetActive(false);
             backendDirector.LeaveGameServer();
             player.Dispose();
+            player = null;
             enemyPlayer.Dispose();
+            enemyPlayer = null;
         }
     }
 }

--- a/Assets/_Scripts/Game/ChessGameDirector.cs
+++ b/Assets/_Scripts/Game/ChessGameDirector.cs
@@ -80,8 +80,10 @@ namespace ChessCrush.Game
                 actionAnimation?.Kill(true);
                 actionAnimation = null;
                 StopAllCoroutines();
+
                 isPlayerWin = false;
                 chessGameUI.gameOverWidget.gameObject.SetActive(true);
+                backendDirector.MatchEnd(isPlayerWin);
             });
 
             enemyPlayer.Hp.Where(value => value <= 0).Subscribe(_ =>
@@ -89,8 +91,10 @@ namespace ChessCrush.Game
                 actionAnimation?.Kill(true);
                 actionAnimation = null;
                 StopAllCoroutines();
+
                 isPlayerWin = true;
                 chessGameUI.gameOverWidget.gameObject.SetActive(true);
+                backendDirector.MatchEnd(isPlayerWin);
             });
 
             gameReadyEvents();

--- a/Assets/_Scripts/Game/Player.cs
+++ b/Assets/_Scripts/Game/Player.cs
@@ -16,6 +16,8 @@ namespace ChessCrush.Game
         public List<ChessAction> chessActions = new List<ChessAction>();
         public Subject<List<ChessAction>> actionsSubject = new Subject<List<ChessAction>>();
 
+        private IDisposable turnCountSubscribe;
+
         private ChessGameDirector chessGameDirector;
 
         public Player()
@@ -65,10 +67,7 @@ namespace ChessCrush.Game
                 });
             }
 
-            chessGameDirector.turnCount.Subscribe(value =>
-            {
-                if (value > 0) EnergyPoint.Value = Mathf.Clamp(EnergyPoint.Value + 1, 0, 10);
-            }).AddTo(chessGameDirector);
+            turnCountSubscribe = chessGameDirector.turnCount.Where(value => value > 0).Subscribe(_ => EnergyPoint.Value = Mathf.Clamp(EnergyPoint.Value + 1, 0, 10));
         }
 
         public void Initialize(int hp,int energy)
@@ -106,6 +105,8 @@ namespace ChessCrush.Game
             Hp.Dispose();
             EnergyPoint.Dispose();
             actionsSubject.Dispose();
+            turnCountSubscribe.Dispose();
+            GC.SuppressFinalize(this);
         }
     }
 }


### PR DESCRIPTION
When player plays game more than twice, there's a bug that player's energy point set 2 points. That's because player and enemy player doesn't set null when game ended.